### PR TITLE
Feature/two way teams

### DIFF
--- a/lib/api/.npmignore
+++ b/lib/api/.npmignore
@@ -1,3 +1,0 @@
-.DS_Store
-npm-debug.log
-node_modules

--- a/lib/api/client/teams.js
+++ b/lib/api/client/teams.js
@@ -40,8 +40,8 @@ Teams.prototype.list = function (username, callback) {
 // #### @callback {function} Continuation to pass control to when complete
 // Creates an application with the specified package.json manifest in `app`. 
 //
-Teams.prototype.create = function (name, callback) {
-  this.request('POST', ['teams', name], callback, function (res, result) {
+Teams.prototype.create = function (name, props, callback) {
+  this.request('POST', ['teams', name], props, callback, function (res, result) {
     callback(null, result || res.statusCode);
   })
 };
@@ -93,6 +93,19 @@ Teams.prototype.destroy = function (name, callback) {
 Teams.prototype.available = function (name, callback) {
   this.request('GET', ['teams', name, 'available'], callback,
       function (res, result) {
+    callback(null, result || res.statusCode);
+  });
+};
+
+//
+// ### function update (name, attrs, callback)
+// #### @appName {string} Name of the application to update
+// #### @attrs {Object} Attributes to update for this application.
+// #### @callback {function} Continuation to pass control to when complete
+// Updates the application with `name` with the specified attributes in `attrs`
+//
+Teams.prototype.invite = function (name, props, callback) {
+  this.request('POST', ['teams', name, 'invite'], props, callback, function (res, result) {
     callback(null, result || res.statusCode);
   });
 };

--- a/lib/api/client/teams.js
+++ b/lib/api/client/teams.js
@@ -3,109 +3,100 @@
  *
  */
 
-var util = require('util'),
-    Client = require('./client').Client;
+var util = require('util');
+var Client = require('./client').Client;
 
-//
-// ### function Teams (options)
-// #### @options {Object} Options for this instance
-// Constructor function for the Teams resource responsible
-// with Nodejitsu's Teams API
-//
+/*
+ * Constructor function for the Teams resource.
+ * @options {Object} Options for this instance.
+ */
 var Teams = exports.Teams = function (options) {
   Client.call(this, options);
 };
 
-// Inherit from Client base object
+// Inherit from Client base object.
 util.inherits(Teams, Client);
 
-//
-// ### function list (username, callback)
-// #### @callback {function} Continuation to pass control to when complete
-// Lists all applications for the authenticated user
-//
-Teams.prototype.list = function (username, callback) {
+/*
+ * Lists all teams for the authenticated user.
+ * @username {string} username of the user to list teams for.
+ * @cb {function} Continuation to pass control to when complete.
+ */
+Teams.prototype.list = function (username, cb) {
   if (arguments.length === 1) {
-    callback = username;
+    cb = username;
     username = this.options.get('username');
   }
-  this.request('GET', ['teams', username], callback, function (res, result) {
-    callback(null, result || res.statusCode);
+  this.request('GET', ['teams', username], cb, function (res, result) {
+    cb(null, result || res.statusCode);
   })
 };
 
-//
-// ### function create (app, callback)
-// #### @app {Object} Package.json manifest for the application.
-// #### @callback {function} Continuation to pass control to when complete
-// Creates an application with the specified package.json manifest in `app`. 
-//
-Teams.prototype.create = function (name, props, callback) {
-  this.request('POST', ['teams', name], props, callback, function (res, result) {
-    callback(null, result || res.statusCode);
+/*
+ * Creates a team.
+ * @props {Object} Properties for the new team.
+ * @cb {function} Continuation to pass control to when complete.
+ */
+Teams.prototype.create = function (name, props, cb) {
+  this.request('POST', ['teams', name], props, cb, function (res, result) {
+    cb(null, result || res.statusCode);
   })
 };
 
-//
-// ### function view (appName, callback)
-// #### @appName {string} Name of the application to view
-// #### @callback {function} Continuation to pass control to when complete
-// Views the application specified by `name`.
-//
-Teams.prototype.view = function (name, callback) {
-  this.request('GET', ['teams', name], callback, function (res, result) {
-    callback(null, result.app || res.statusCode);
+/*
+ * Views the team specified by `name`.
+ * @name {string} Name of the team to view.
+ * @cb {function} Continuation to pass control to when complete.
+ */
+Teams.prototype.view = function (name, cb) {
+  this.request('GET', ['teams', name], cb, function (res, result) {
+    cb(null, result.app || res.statusCode);
   })
 };
 
-//
-// ### function update (name, attrs, callback)
-// #### @appName {string} Name of the application to update
-// #### @attrs {Object} Attributes to update for this application.
-// #### @callback {function} Continuation to pass control to when complete
-// Updates the application with `name` with the specified attributes in `attrs`
-//
-Teams.prototype.update = function (name, props, callback) {
-  this.request('PUT', ['teams', name], props, callback, function (res, result) {
-    callback(null, result || res.statusCode);
+/*
+ * Updates the team with `name` with the specified `props`.
+ * @name {string} Name of the team to update.
+ * @props {Object} Properties to update.
+ * @cb {function} Continuation to pass control to when complete.
+ */
+Teams.prototype.update = function (name, props, cb) {
+  this.request('PUT', ['teams', name], props, cb, function (res, result) {
+    cb(null, result || res.statusCode);
   });
 };
 
-//
-// ### function destroy (appName, callback)
-// #### @appName {string} Name of the application to destroy
-// #### @callback {function} Continuation to pass control to when complete
-// Destroys the application with `name` for the authenticated user. 
-//
-Teams.prototype.destroy = function (name, callback) {
-  this.request('DELETE', ['teams', name], callback, function (res, result) {
-    callback(null, result || res.statusCode);
+/*
+ * Destroys the team with `name` for the authenticated user. 
+ * @name {string} Name of the team to destroy.
+ * @cb {function} Continuation to pass control to when complete.
+ */
+Teams.prototype.destroy = function (name, cb) {
+  this.request('DELETE', ['teams', name], cb, function (res, result) {
+    cb(null, result || res.statusCode);
   })
 };
 
-//
-// ### function available (app, callback)
-// #### @app {Object} Application to check availability against.
-// #### @callback {function} Continuation to respond to when complete.
-// Checks the availability of the `app.name` / `app.subdomain` combo 
-// in the current Nodejitsu environment.
-//
-Teams.prototype.available = function (name, callback) {
-  this.request('GET', ['teams', name, 'available'], callback,
+/*
+ * Checks the availability of the specified `name`.
+ * @name {string} Name of the team to check availability against.
+ * @cb {function} Continuation to pass control to when complete.
+ */
+Teams.prototype.available = function (name, cb) {
+  this.request('GET', ['teams', name, 'available'], cb,
       function (res, result) {
-    callback(null, result || res.statusCode);
+    cb(null, result || res.statusCode);
   });
 };
 
-//
-// ### function update (name, attrs, callback)
-// #### @appName {string} Name of the application to update
-// #### @attrs {Object} Attributes to update for this application.
-// #### @callback {function} Continuation to pass control to when complete
-// Updates the application with `name` with the specified attributes in `attrs`
-//
-Teams.prototype.invite = function (name, props, callback) {
-  this.request('POST', ['teams', name, 'invite'], props, callback, function (res, result) {
-    callback(null, result || res.statusCode);
+/*
+ * Invites an existing user to an existing team.
+ * @name {string} Name of the team for invite.
+ * @props {Object} Properties of the invite (inviter, invitee).
+ * @cb {function} Continuation to pass control to when complete.
+ */
+Teams.prototype.invite = function (name, props, cb) {
+  this.request('POST', ['teams', name, 'invite'], props, cb, function (res, result) {
+    cb(null, result || res.statusCode);
   });
 };

--- a/lib/api/client/users.js
+++ b/lib/api/client/users.js
@@ -3,137 +3,127 @@
  *
  */
  
-var util = require('util'),
-    Client = require('./client').Client;
-    
-//
-// ### function Users (options)
-// #### @options {Object} Options for this instance
-// Constructor function for the Users resource responsible
-// with Nodejitsu's Users API
-//
+var util = require('util');
+var Client = require('./client').Client;
+
+/*
+ * Constructor function for the Users resource.
+ * @options {Object} Options for this instance.
+ */
 var Users = exports.Users = function (options) {
   Client.call(this, options);
 };
 
-// Inherit from Client base object
+// Inherit from Client base object.
 util.inherits(Users, Client);
 
-//
-// ### function auth (callback)
-// #### @callback {function} Continuation to pass control to when complete
-// Tests the authentication of the user identified in this process.
-//
-Users.prototype.auth = function (callback) {
-  this.request('GET', ['auth'], callback, function (res, body) {
-    callback(null, true);
+/*
+ * Tests the authentication of the user identified in this process.
+ * @cb {function} Continuation to pass control to when complete.
+ */
+Users.prototype.auth = function (cb) {
+  this.request('GET', ['auth'], cb, function (res, body) {
+    cb(null, true);
   });
 };
 
-//
-// ### function create (user, callback) 
-// #### @user {Object} Properties for the new user.
-// #### @callback {function} Continuation to pass control to when complete
-// Creates a new user with the properties specified by `user`.
-//
-Users.prototype.create = function (user, callback) {
-  this.request('POST', ['users', user.username], user, callback,
+/*
+ * Creates a new user with the properties specified by `user`.
+ * @props {Object} Properties for the new user.
+ * @cb {function} Continuation to pass control to when complete.
+ */
+Users.prototype.create = function (props, cb) {
+  this.request('POST', ['users', props.username], props, cb,
       function (res, result) {
-    callback();
+    cb();
   });
 };
 
-//
-// ### function available (username, callback) 
-// #### @username {string} Username to check availability for.
-// #### @callback {function} Continuation to pass control to when complete
-// Checks the availability of the specified `username`.
-//
-Users.prototype.available = function (username, callback) {
-  this.request('GET', ['users', username, 'available'], callback,
+/*
+ * Checks the availability of the specified `username`.
+ * @username {string} Username to check availability for.
+ * @cb {function} Continuation to pass control to when complete.
+ */
+Users.prototype.available = function (username, cb) {
+  this.request('GET', ['users', username, 'available'], cb,
       function (res, result) {
-    callback(null, result);
+    cb(null, result);
   });
 };
 
-//
-// ### function view (username, callback)
-// #### @callback {function} Continuation to pass control to when complete.
-// Retrieves data for the specified user.
-//
-Users.prototype.view = function (username, callback) {
-  this.request('GET', ['users', username], callback,
+/*
+ * Retrieves data for the specified user.
+ * @username {string} Username of user to view.
+ * @cb {function} Continuation to pass control to when complete.
+ */
+Users.prototype.view = function (username, cb) {
+  this.request('GET', ['users', username], cb,
       function (res, result) {
-    callback(null, result);
+    cb(null, result);
   });
 };
 
-//
-// ### function view (username, callback)
-// #### @callback {function} Continuation to pass control to when complete.
-// Retrieves data for the specified user.
-//
-Users.prototype.list = function (callback) {
-  this.request('GET', ['users'], callback,
-      function (res, result) {
-    callback(null, result);
+/*
+ * Retrieves all users.
+ * @cb {function} Continuation to pass control to when complete.
+ */
+Users.prototype.list = function (cb) {
+  this.request('GET', ['users'], cb, function (res, result) {
+    cb(null, result);
   });
 };
 
-//
-// ### function confirm (user, callback)
-// #### @user {Object} Properties for the user to confirm.
-// #### @callback {function} Continuation to pass control to when complete
-// Confirms the specified `user` by sending the invite code in the `user` specified.
-//
-Users.prototype.confirm = function (props, callback) {
+/*
+ * Confirms the specified `user` with `props`.
+ * @props {Object} Properties for the user to confirm.
+ * @cb {function} Continuation to pass control to when complete.
+ */
+Users.prototype.confirm = function (props, cb) {
   this.request('POST', ['users', props.username, 'confirm'],
-      props, callback, function (res, result) {
-    callback(null, result);
+      props, cb, function (res, result) {
+    cb(null, result);
   });
 };
 
-//
-// ### function forgot (username, callback) 
-// #### @username {Object} username requesting password reset.
-// #### @params {Object} Object containing shake and new password, if applicable.
-// #### @callback {function} Continuation to pass control to when complete
-// Request an password reset email.
-//
-Users.prototype.forgot = function (username, params, callback) {
-  if (!callback && typeof params == 'function') {
-    callback = params;
-    params = {};
+/*
+ * Request an password reset email.
+ * @username {String} username requesting password reset.
+ * @props {Object} Object containing shake and new password, if applicable.
+ * @cb {function} Continuation to pass control to when complete.
+ */
+Users.prototype.forgot = function (username, props, cb) {
+  if (!cb && typeof props === 'function') {
+    cb = props;
+    props = {};
   }
 
-  this.request('POST', ['users', username, 'forgot'], params, callback, function (res, result) {
-    return callback(null, result);
+  this.request('POST', ['users', username, 'forgot'],
+      props, cb, function (res, result) {
+    return cb(null, result);
   });
 };
 
-//
-// ### function update (username, object, callback)
-// #### @username {Object} username requesting password reset.
-// #### @object {Object} Updated information about user
-// #### @callback {function} Continuation to pass control to when complete
-// Update user account information.
-//
-Users.prototype.update = function (username, object, callback) {
-  this.request('PUT', ['users', username], object, callback, function (res, result) {
-    callback(null, result);
+/*
+ * Update user account information.
+ * @username {String} username requesting update.
+ * @props {Object} Updated information about user.
+ * @cb {function} Continuation to pass control to when complete.
+ */
+Users.prototype.update = function (username, props, cb) {
+  this.request('PUT', ['users', username],
+      props, cb, function (res, result) {
+    cb(null, result);
   });
 };
 
-//
-// ### function destroy (username, callback)
-// #### @username {String} User to delete
-// #### @callback {function} Continuation to pass control to when complete
-// Delete user account. Use with extreme caution.
-//
-// So sad to see you go.
-//
-Users.prototype.destroy = function (username, callback) {
-  this.request('DELETE', ['users', username], callback, function (res, result) {
-    callback(null, result);
+/*
+ * Delete user account. Use with extreme caution. So sad to see you go.
+ * @username {String} User to delete.
+ * @cb {function} Continuation to pass control to when complete.
+ */
+Users.prototype.destroy = function (username, cb) {
+  this.request('DELETE', ['users', username],
+      cb, function (res, result) {
+    cb(null, result);
   });
 };

--- a/lib/grr.js
+++ b/lib/grr.js
@@ -3,10 +3,10 @@
  *
  */
 
-var path = require('path'),
-    util = require('util'),
-    colors = require('colors'),
-    flatiron = require('flatiron');
+var path = require('path');
+var util = require('util');
+var colors = require('colors');
+var flatiron = require('flatiron');
 
 var grr = module.exports = flatiron.app;
 
@@ -186,24 +186,6 @@ grr.exec = function (command, callback) {
     if (err) {
       return callback(err);
     }
-
-    //
-    // Remark: This is a temporary fix for aliasing init=>install,
-    // was having a few issues with the alias command on the install resource
-    //
-    // if (command[0] === 'init') {
-    //   command[0] = 'install';
-    // }
-
-    // Alias db to databases
-    // if (command[0] === 'db' || command[0] === 'dbs' || command[0] === 'database') {
-    //   command[0] = 'databases';
-    // }
-
-    // Allow `grr logs` as a shortcut for `grr logs app`
-    // if (command[0] === 'logs' && command.length === 1) {
-    //   command[1] = 'app';
-    // }
 
     grr.log.info('Executing command ' + command.join(' ').magenta);
     grr.router.dispatch('on', command.join(' '), grr.log, function (err, shallow) {

--- a/lib/grr/commands/teams.js
+++ b/lib/grr/commands/teams.js
@@ -1,12 +1,12 @@
 /*
- * teams.js: Commands related to team resources
+ * teams.js: Commands related to team resources.
  *
  */
 
-var analyzer = require('require-analyzer'),
-    opener   = require('opener'),
-    grr    = require('../../grr'),
-    utile    = grr.common;
+var analyzer = require('require-analyzer');
+var opener = require('opener');
+var grr = require('../../grr');
+var utile = grr.common;
 var _ = require('underscore');
 _.mixin(require('underscore.string'));
 
@@ -21,18 +21,17 @@ teams.usage = [
   'grr teams invite [<username>] [<teamname>]'
 ];
 
-//
-// ### function create (callback)
-// #### @target {string|Object} **optional** Name of the application to create
-// #### @callback {function} Continuation to pass control to when complete.
-// Creates an application for the package.json in the current directory
-// using `name` if supplied and falling back to `package.name`.
-//
-teams.create = function (name, callback) {
+
+/*
+ * Creates a new team.
+ * @name {string} **optional** Name of the team to create
+ * @cb {function} Continuation to pass control to when complete.
+ */
+teams.create = function (name, cb) {
 
   // Allows arbitrary amount of arguments.
   if (arguments.length)
-    callback = utile.args(arguments).callback;
+    cb = utile.args(arguments).cb;
 
   // Recursively check availability.
   var username = grr.config.get('username');
@@ -40,7 +39,7 @@ teams.create = function (name, callback) {
     if (err) {
       grr.log.error('Error creating team ' + n.magenta);
       grr.log.error(err.message);
-      return callback(err);    
+      return cb(err);    
     }
     var callee = arguments.callee;
     if (!n)
@@ -55,55 +54,46 @@ teams.create = function (name, callback) {
     });
   })(function (err, n) {
     grr.log.info('Creating team ' + n.magenta);
-    grr.teams.create(n, {username: username}, callback);
+    grr.teams.create(n, {username: username}, cb);
   }, null, name);
 
 };
 
-//
 // Usage for `grr apps create`.
-//
 teams.create.usage = [
-  'Attempts to create a new team with name.',
+  'Creates a new team with name.',
   '',
   'grr teams create [<name>]'
 ];
 
-//
-// ### function invite (callback)
-// #### @target {string|Object} **optional** Name of the application to create
-// #### @callback {function} Continuation to pass control to when complete.
-// Creates an application for the package.json in the current directory
-// using `name` if supplied and falling back to `package.name`.
-//
-teams.invite = function (invitee, name, callback) {
+/* 
+ * Invites a user to a team.
+ * @invitee {string} Username of the user to invite.
+ * @cb {function} Continuation to pass control to when complete.
+ */
+teams.invite = function (invitee, name, cb) {
 
   // Allows arbitrary amount of arguments.
   if (arguments.length)
-    callback = utile.args(arguments).callback;
+    cb = utile.args(arguments).cb;
 
   var username = grr.config.get('username');
   grr.log.info('Inviting ' + invitee.magenta + ' to team ' + name.magenta);
-  grr.teams.invite(name, {inviter: username, invitee: invitee}, callback);
+  grr.teams.invite(name, {inviter: username, invitee: invitee}, cb);
 };
 
-//
 // Usage for `grr teams invite`.
-//
 teams.invite.usage = [
-  'Attempts to invite an existing user to an existing team.',
+  'Invites an existing user to an existing team.',
   '',
   'grr teams invite [<username>] [<teamname>]'
 ];
 
-//
-// ### function confirm (username, callback)
-// #### @username {string} Desired username to confirm
-// #### @callback {function} Continuation to pass control to when complete.
-// Attempts to confirm the Wolfpack user account with the specified `username`.
-// Prompts the user for additional `invite` information.
-//
-teams.list = function (callback) {
+/* 
+ * Lists all teams that the logged in user is a member of.
+ * @cb {function} Continuation to pass control to when complete.
+ */
+teams.list = function (cb) {
 
   // Allows arbitrary amount of arguments.
   if (arguments.length)
@@ -113,11 +103,11 @@ teams.list = function (callback) {
   grr.log.info('Fetching all teams for ' + username.magenta);
   grr.teams.list(username, function (err, response) {
     if (err)
-      return callback(err);
+      return cb(err);
 
     if (response.error) {
       grr.log.error(response.error);
-      return callback(response.error);
+      return cb(response.error);
     }
 
     grr.log.info('Found ' + String(response.teams.length).cyan + ' teams');
@@ -125,29 +115,27 @@ teams.list = function (callback) {
       grr.log.info(team.name.magenta);
       _.each(team.users, function (conf, un) {
         grr.log.info('  ' + un.cyan + ' -> '
-                          + 'updates: '
-                          + ((conf.updates.daily ? 'daily ':'')
-                          + (conf.updates.micro ? 'micro ':'')
-                          + (!conf.updates.daily && !conf.updates.micro ? 'none ':'')).bold
-                          + '| recaps: '
-                          + ((conf.recaps.daily ? 'daily ':'')
-                          + (conf.recaps.weekly ? 'weekly ':'')
-                          + (!conf.recaps.daily && !conf.recaps.weekly ? 'none ':'')).bold);
+            + 'updates: '
+            + ((conf.updates.daily ? 'daily ':'')
+            + (conf.updates.micro ? 'micro ':'')
+            + (!conf.updates.daily && !conf.updates.micro ? 'none ':'')).bold
+            + '| recaps: '
+            + ((conf.recaps.daily ? 'daily ':'')
+            + (conf.recaps.weekly ? 'weekly ':'')
+            + (!conf.recaps.daily && !conf.recaps.weekly ? 'none ':'')).bold);
                           
       });
     });
     
-    callback();
+    cb();
     
   });
 
 };
 
-//
 // Usage for `grr teams list`.
-//
 teams.list.usage = [
-  'Shows all teams for a certain user',
+  'Shows all teams for the user',
   '',
   'grr teams list'
 ];

--- a/lib/grr/commands/teams.js
+++ b/lib/grr/commands/teams.js
@@ -18,7 +18,7 @@ teams.usage = [
   '',
   'grr teams create',
   'grr teams list',
-  'grr teams add [<username>] [<teamname>]'
+  'grr teams invite [<username>] [<teamname>]'
 ];
 
 //
@@ -47,7 +47,7 @@ teams.create = function (name, callback) {
       return grr.prompt.get(['name'], _.bind(callee, this, cb));
     if (_.isObject(n)) n = n.name;
     grr.log.info('Checking team availability ' + n.magenta);
-    grr.teams.available([username, n].join('/'), function (err, result) {
+    grr.teams.available(n, function (err, result) {
       if (200 === result)
         return cb(null, n);
       grr.log.error('Name was already taken');
@@ -55,50 +55,45 @@ teams.create = function (name, callback) {
     });
   })(function (err, n) {
     grr.log.info('Creating team ' + n.magenta);
-    grr.teams.create([username, n].join('/'), callback);
+    grr.teams.create(n, {username: username}, callback);
   }, null, name);
 
 };
 
 //
-// Usage for `jitsu apps create`.
+// Usage for `grr apps create`.
 //
 teams.create.usage = [
   'Attempts to create a new team with name.',
   '',
-  'jitsu teams create [<name>]'
+  'grr teams create [<name>]'
 ];
 
 //
-// ### function add (callback)
+// ### function invite (callback)
 // #### @target {string|Object} **optional** Name of the application to create
 // #### @callback {function} Continuation to pass control to when complete.
 // Creates an application for the package.json in the current directory
 // using `name` if supplied and falling back to `package.name`.
 //
-teams.add = function (add, name, callback) {
+teams.invite = function (invitee, name, callback) {
 
   // Allows arbitrary amount of arguments.
   if (arguments.length)
     callback = utile.args(arguments).callback;
 
   var username = grr.config.get('username');
-  var user = {
-    username: add,
-    updates: {daily: true, micro: false},
-    recaps: {daily: true, weekly: true}
-  };
-  grr.log.info('Adding ' + add.magenta + ' to team ' + name.magenta);
-  grr.teams.update([username, name].join('/'), user, callback);
+  grr.log.info('Inviting ' + invitee.magenta + ' to team ' + name.magenta);
+  grr.teams.invite(name, {inviter: username, invitee: invitee}, callback);
 };
 
 //
-// Usage for `jitsu teams add`.
+// Usage for `grr teams invite`.
 //
-teams.add.usage = [
-  'Attempts to add a username to an existing team.',
+teams.invite.usage = [
+  'Attempts to invite an existing user to an existing team.',
   '',
-  'jitsu teams add [<username>] [<teamname>]'
+  'grr teams invite [<username>] [<teamname>]'
 ];
 
 //
@@ -125,21 +120,21 @@ teams.list = function (callback) {
       return callback(response.error);
     }
 
+    grr.log.info('Found ' + String(response.teams.length).cyan + ' teams');
     _.each(response.teams, function (team) {
       grr.log.info(team.name.magenta);
-      if (team.users)
-        _.each(team.users, function (conf, un) {
-          grr.log.info('  ' + un.cyan + ' -> '
-                            + 'updates: '
-                            + ((conf.updates.daily ? 'daily ':'')
-                            + (conf.updates.micro ? 'micro ':'')
-                            + (!conf.updates.daily && !conf.updates.micro ? 'none ':'')).bold
-                            + '| recaps: '
-                            + ((conf.recaps.daily ? 'daily ':'')
-                            + (conf.recaps.weekly ? 'weekly ':'')
-                            + (!conf.recaps.daily && !conf.recaps.weekly ? 'none ':'')).bold);
-                            
-        });
+      _.each(team.users, function (conf, un) {
+        grr.log.info('  ' + un.cyan + ' -> '
+                          + 'updates: '
+                          + ((conf.updates.daily ? 'daily ':'')
+                          + (conf.updates.micro ? 'micro ':'')
+                          + (!conf.updates.daily && !conf.updates.micro ? 'none ':'')).bold
+                          + '| recaps: '
+                          + ((conf.recaps.daily ? 'daily ':'')
+                          + (conf.recaps.weekly ? 'weekly ':'')
+                          + (!conf.recaps.daily && !conf.recaps.weekly ? 'none ':'')).bold);
+                          
+      });
     });
     
     callback();
@@ -156,88 +151,3 @@ teams.list.usage = [
   '',
   'grr teams list'
 ];
-
-//
-// ### function list (callback)
-// #### @callback {function} Continuation to pass control to when complete.
-// Lists the teams for the authenticated user.
-//
-// teams.list = function (username, callback) {
-
-//   var authuser = grr.config.get('username') || '';
-
-//   if(arguments.length) {
-//     var args = utile.args(arguments);
-//     callback = args.callback;
-//     username = args[0] || authuser;
-//   }
-
-//   if (authuser === '') {
-//     return grr.commands.users.login(function (err) {
-//       if (err) {
-//         return callback(err);
-//       }
-
-//       grr.commands.teams.list(username, callback);
-//     });
-//   }
-
-//   if (authuser === '') {
-//     return grr.commands.users.login(function (err) {
-//       if (err) {
-//         return callback(err);
-//       }
-
-//       grr.commands.teams.list(username, callback);
-//     });
-//   }
-
-//   grr.log.info('Listing all teams for ' + username.magenta);
-
-//   grr.teams.list(username, function cb(err, teams) {
-//     if (err) {
-//       if (err.statusCode === 403) {
-//         if (authuser === '') {
-//           grr.log.error('You are not authorized to list application for user: ' + username.magenta);
-//           grr.log.error('You need to login to do that!');
-//         }
-//         else {
-//           grr.log.error(grr.config.get('username').magenta + ' is not authorized to list applications for user: ' + username.magenta);
-//         }
-//       }
-//       return callback(err);
-//     }
-
-//     if (!teams || teams.length === 0) {
-//       grr.log.warn('No applications exist.');
-//       grr.log.help('Try creating one with ' + 'grr install'.magenta + ' and then deploy it with ' + 'grr deploy'.magenta);
-//       return callback();
-//     }
-
-//     var rows = [['name', 'state', 'subdomain', 'drones', 'running snapshot']],
-//         colors = ['underline', 'underline', 'underline', 'underline', 'underline'];
-
-//     teams.forEach(function (app) {
-//       app.state = grr.common.formatAppState(app.state);
-
-//       //
-//       // Remark: Attempt to always show running snapshot
-//       //
-//       var snapshot = '---';
-//       if(app.running && app.running.filename) {
-//         snapshot = app.running.filename;
-//       }
-
-//       rows.push([
-//         app.name,
-//         app.state,
-//         app.subdomain,
-//         app.drones + '/' + app.maxDrones,
-//         snapshot
-//       ]);
-//     });
-
-//     grr.inspect.putRows('data', rows, colors);
-//     callback();
-//   });
-// };

--- a/lib/grr/commands/users.js
+++ b/lib/grr/commands/users.js
@@ -97,6 +97,8 @@ users.list = function (callback) {
       grr.log.error(response.error);
       return callback(response.error);
     }
+
+    grr.log.info('Found ' + String(response.users.length).cyan + ' users');
     _.each(response.users, function (user) {
       grr.log.info(user.magenta);
     });

--- a/lib/grr/commands/users.js
+++ b/lib/grr/commands/users.js
@@ -3,27 +3,27 @@
  *
  */
 
-var grr = require('../../grr'),
-    utile = grr.common;
+var grr = require('../../grr');
+var utile = grr.common;
 
 var _ = require('underscore');
 _.mixin(require('underscore.string'));
 
 var users = exports;
 
-//
-// ### function confirm (username, callback)
-// #### @username {string} Desired username to confirm
-// #### @callback {function} Continuation to pass control to when complete.
-// Attempts to confirm the Wolfpack user account with the specified `username`.
-// Prompts the user for additional `invite` information.
-//
-users.confirm = function (username, invite, callback) {
+/* 
+ * Attempts to confirm the user account with the specified `username`.
+ * Prompts the user for `invite` if needed.
+ * @username {string} Desired username to confirm.
+ * @invite {string} Invite code sent in welcome email.
+ * @cb {function} Continuation to pass control to when complete.
+ */
+users.confirm = function (username, invite, cb) {
 
   // Allows arbitrary amount of arguments.
   if (arguments.length) {
     var args = utile.args(arguments);
-    callback = args.callback;
+    cb = args.cb;
     username = args[0] || null;
     invite = args[1] || null;
   }
@@ -49,25 +49,24 @@ users.confirm = function (username, invite, callback) {
     grr.log.info('Confirming user ' + username.magenta);
     grr.users.confirm(user, function (err, response) {
       if (err)
-        return callback(err);
+        return cb(err);
 
       if (response.error) {
         grr.log.error(response.error);
-        return callback(response.error);
+        return cb(response.error);
       }
 
       grr.log.info('User ' + username.magenta + ' confirmed');
       grr.log.info('You may now run ' + 'grr login'.magenta);
-      callback();
+      cb();
       
     });
   })(username, invite);
 
 };
 
-//
+
 // Usage for `grr users confirm`.
-//
 users.confirm.usage = [
   'Confirms a Wolfpack user account',
   'Will prompt for a valid invite code for the account',
@@ -75,14 +74,12 @@ users.confirm.usage = [
   'grr users confirm <username> <invitecode>'
 ];
 
-//
-// ### function confirm (username, callback)
-// #### @username {string} Desired username to confirm
-// #### @callback {function} Continuation to pass control to when complete.
-// Attempts to confirm the Wolfpack user account with the specified `username`.
-// Prompts the user for additional `invite` information.
-//
-users.list = function (callback) {
+
+/* 
+ * Lists all users.
+ * @cb {function} Continuation to pass control to when complete.
+ */
+users.list = function (cb) {
 
   // Allows arbitrary amount of arguments.
   if (arguments.length)
@@ -91,11 +88,11 @@ users.list = function (callback) {
   grr.log.info('Fetching all users');
   grr.users.list(function (err, response) {
     if (err)
-      return callback(err);
+      return cb(err);
 
     if (response.error) {
       grr.log.error(response.error);
-      return callback(response.error);
+      return cb(response.error);
     }
 
     grr.log.info('Found ' + String(response.users.length).cyan + ' users');
@@ -103,15 +100,13 @@ users.list = function (callback) {
       grr.log.info(user.magenta);
     });
     
-    callback();
+    cb();
     
   });
 
 };
 
-//
 // Usage for `grr users list`.
-//
 users.list.usage = [
   'Shows all users',
   '',

--- a/lib/grr/config.js
+++ b/lib/grr/config.js
@@ -56,7 +56,7 @@ var defaults = {
   localHost: 'localhost',
   localPort: 9090,
   remoteHost: 'api.grr.io',
-  requiresAuth: ['teams'],
+  requiresAuth: ['users', 'teams'],
   root: process.env.HOME,
   timeout: 4 * 60 * 1000,
   tmproot: path.join(process.env.HOME, '.grr/tmp'),

--- a/lib/grr/usage.js
+++ b/lib/grr/usage.js
@@ -37,6 +37,6 @@ module.exports = [
 
   'Additional Commands'.cyan.bold.underline,
   '  grr teams create',
-  '  grr teams add',
+  '  grr teams invite <username> <teamname>',
   '  grr users list',
 ];


### PR DESCRIPTION
This adds support for the original kind of team we had talked about ... so you can now do...

```
grr teams create bedroom
grr teams invite princess bedroom
```

At which point an email is sent to `princess` asking her if she wants to join. The response is send to the inviter, accepted or declined.

I realized it's much easy for development to use `npm link` to map the dev `grr` binary to global npm dir... so can...

```
[sudo] npm uninstall grr -g
git clone git@github.com:sanderpick/wolfpack-cli.git
cd wolfpack-cli
npm link
which grr
```

That should work .. now the `grr` in user path should be the grr in `/wolfpack-cli/bin/grr`. 

Before merge, I'll make some comments on the changes... maybe later... maybe in the morning :)
